### PR TITLE
Drop libsoup3 module

### DIFF
--- a/com.github.louis77.tuner.yml
+++ b/com.github.louis77.tuner.yml
@@ -77,5 +77,6 @@ modules:
   sources:
     - type: git
       url: https://github.com/tuner-labs/tuner.git
-      tag: v2.0.1-beta.1 
+      tag: v2.0.1-beta.1
+      commit: b4f5af9d529fc70a2bc7a140b48ca9ff12a8366c
       

--- a/com.github.louis77.tuner.yml
+++ b/com.github.louis77.tuner.yml
@@ -46,21 +46,6 @@ modules:
   build-commands:
     - install -d /app/vala
 
-- name: libsoup
-  buildsystem: meson
-  builddir: true
-  config-opts:
-    - "--buildtype=release"
-    - "-Dvapi=enabled"
-    - "-Dtests=false"
-    - "-Dgssapi=disabled"
-    - "-Dsysprof=disabled"
-  sources:
-    - type: git
-      url: https://gitlab.gnome.org/GNOME/libsoup.git
-      tag: 3.6.5
-      commit: 766e17528251c9b696a6076300ac61adc95536ac
-
 - name: gee
   buildsystem: autotools
   build-options:


### PR DESCRIPTION
Freedesktop runtime 25.08 already provides this module.

```
grep libsoup -a4 /usr/manifest.json 
"product": "libsoup",
"version": "3.6.5"
"url": "https://gitlab.gnome.org/GNOME/libsoup.git",
```

Fixes: https://github.com/flathub/com.github.louis77.tuner/issues/42